### PR TITLE
example 06 with float128

### DIFF
--- a/example/fft_ex06_float128.cpp
+++ b/example/fft_ex06_float128.cpp
@@ -1,0 +1,78 @@
+///////////////////////////////////////////////////////////////////
+//  Copyright Eduardo Quintana 2021
+//  Copyright Janek Kozicki 2021
+//  Copyright Christopher Kormanyos 2021
+//  Distributed under the Boost Software License,
+//  Version 1.0. (See accompanying file LICENSE_1_0.txt
+//  or copy at http://www.boost.org/LICENSE_1_0.txt)
+/*
+    boost::math::fft example 06
+    
+    Fast Polynomial Multiplication with quadmath
+*/
+
+#include <boost/math/fft/bsl_backend.hpp>
+#include <boost/multiprecision/float128.hpp>
+#include <iostream>
+#include <vector>
+#include <exception>
+
+template<class T>
+std::vector<T> multiply_complex(const std::vector<T>& A, const std::vector<T>& B)
+{
+  const std::size_t N = A.size();
+  std::vector< boost::multiprecision::complex<T> > TA(N),TB(N);
+  boost::math::fft::bsl_rdft<T> P(N); 
+  P.real_to_complex(A.begin(),A.end(),TA.begin());
+  P.real_to_complex(B.begin(),B.end(),TB.begin());
+  
+  std::vector<T> C(N);
+  
+  for(unsigned int i=0;i<N;++i)
+  {
+    TA[i]*=TB[i];
+  }
+  
+  P.complex_to_real(TA.begin(),TA.end(),C.begin());
+  std::transform(C.begin(), C.end(), C.begin(),
+                 [N](T x) { return x / N; });
+  
+  return C;
+}
+
+template<class T>
+T difference(const std::vector<T>& A, const std::vector<T>& B)
+{
+  using std::abs;
+  T diff{};
+  if(A.size()!=B.size()) return -1;
+  for(unsigned int i=0;i<A.size();++i)
+  {
+    diff += abs(A[i]-B[i]);
+  }
+  return diff;
+}
+
+template<typename Real>
+void multiply() {
+  using std::abs;
+  std::vector<Real> A{1.,4.,-5.,1.,0.,0.,0.,0.};
+  std::vector<Real> B{-1.,1.,2.,3.,0.,0.,0.,0.};
+  std::vector<Real> C{-1,-3,11,5,3,-13,3,0};
+  
+  std::vector<Real> result;
+  Real diff;
+  
+  result = multiply_complex(A,B);
+  diff = difference(result,C);
+  if(abs(diff)>1e-3) 
+    throw std::runtime_error("wrong result");
+}
+
+int main()
+{
+  multiply<::boost::multiprecision::float128>();
+  return 0;
+}
+
+

--- a/example/fft_ex06_float128.cpp
+++ b/example/fft_ex06_float128.cpp
@@ -12,21 +12,23 @@
 */
 
 #include <boost/math/fft/bsl_backend.hpp>
-#include <boost/multiprecision/float128.hpp>
+#include <boost/multiprecision/complex128.hpp>
 #include <iostream>
 #include <vector>
 #include <exception>
 
-template<class T>
-std::vector<T> multiply_complex(const std::vector<T>& A, const std::vector<T>& B)
+template<class Real, class Complex>
+std::vector<Real> multiply_complex(
+    const std::vector<Real>& A, 
+    const std::vector<Real>& B)
 {
   const std::size_t N = A.size();
-  std::vector< boost::multiprecision::complex<T> > TA(N),TB(N);
-  boost::math::fft::bsl_rdft<T> P(N); 
+  std::vector< Complex > TA(N),TB(N);
+  boost::math::fft::bsl_rdft<Real> P(N); 
   P.real_to_complex(A.begin(),A.end(),TA.begin());
   P.real_to_complex(B.begin(),B.end(),TB.begin());
   
-  std::vector<T> C(N);
+  std::vector<Real> C(N);
   
   for(unsigned int i=0;i<N;++i)
   {
@@ -35,16 +37,16 @@ std::vector<T> multiply_complex(const std::vector<T>& A, const std::vector<T>& B
   
   P.complex_to_real(TA.begin(),TA.end(),C.begin());
   std::transform(C.begin(), C.end(), C.begin(),
-                 [N](T x) { return x / N; });
+                 [N](Real x) { return x / N; });
   
   return C;
 }
 
-template<class T>
-T difference(const std::vector<T>& A, const std::vector<T>& B)
+template<class Real>
+Real difference(const std::vector<Real>& A, const std::vector<Real>& B)
 {
   using std::abs;
-  T diff{};
+  Real diff{};
   if(A.size()!=B.size()) return -1;
   for(unsigned int i=0;i<A.size();++i)
   {
@@ -53,7 +55,7 @@ T difference(const std::vector<T>& A, const std::vector<T>& B)
   return diff;
 }
 
-template<typename Real>
+template<typename Real, typename Complex>
 void multiply() {
   using std::abs;
   std::vector<Real> A{1.,4.,-5.,1.,0.,0.,0.,0.};
@@ -63,7 +65,7 @@ void multiply() {
   std::vector<Real> result;
   Real diff;
   
-  result = multiply_complex(A,B);
+  result = multiply_complex<Real,Complex>(A,B);
   diff = difference(result,C);
   if(abs(diff)>1e-3) 
     throw std::runtime_error("wrong result");
@@ -71,7 +73,9 @@ void multiply() {
 
 int main()
 {
-  multiply<::boost::multiprecision::float128>();
+  multiply<
+    ::boost::multiprecision::float128,
+    ::boost::multiprecision::complex128>();
   return 0;
 }
 

--- a/test/Jamfile.v2
+++ b/test/Jamfile.v2
@@ -1478,6 +1478,7 @@ test-suite fft :
    [ run ../example/fft_ex04.cpp ../config//fftw3 : : : ]
    [ run ../example/fft_ex05.cpp ../config//fftw3 ../config//fftw3f ../config//fftw3l ../config//fftw3q ../config//quadmath ../config//gsl ../tools//mpfr ../tools//gmp ../tools//mpc : <include>../../multiprecision/include ../tools//mpfr ../tools//gmp : : [ check-target-builds ../config//has_mpfr : : <build>no ]  ]
    [ run ../example/fft_ex06.cpp : : :  ]
+   [ run ../example/fft_ex06_float128.cpp ../config//quadmath : : :  ]
    [ run ../example/fft_ex07.cpp  ../config//fftw3 ../config//gsl : : :  ]
    [ run ../example/fft_ex08.cpp : : :  ]
    [ run ../example/fft_ex09.cpp : : :  ]


### PR DESCRIPTION
I added a version of the example 06 with boost::multiprecision::float128 working on the bsl backend.
In my local environment this example works, there are checks included for correctness.
If the CI tests pass then we can close issue #18.